### PR TITLE
AWS Cloudfront 403 error fix

### DIFF
--- a/offat/tester/test_runner.py
+++ b/offat/tester/test_runner.py
@@ -79,7 +79,7 @@ class TestRunner:
         body_params = test_task.get('body_params')
         query_params = test_task.get('query_params')
 
-        if body_params:
+        if body_params and str(http_method).upper() not in ['GET', 'OPTIONS']:
             kwargs['json'] = self._generate_payloads(body_params, payload_for=PayloadFor.BODY)
 
         if query_params:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "offat"
-version = "0.4.0"
+version = "0.4.1"
 description = "Offensive API tester tool automates checks for common API vulnerabilities"
 authors = ["Dhrumil Mistry <56185972+dmdhrumilmistry@users.noreply.github.com>"]
 license = "MIT"


### PR DESCRIPTION
do not send json payload for GET and OPTIONS HTTP methods