### PR TITLE
Update CICD Docker deployment workflow

### DIFF
--- a/.github/workflows/dev-push.yml
+++ b/.github/workflows/dev-push.yml
@@ -1,0 +1,50 @@
+name: "Build and Push Docker Image to DockerHub"
+
+on:
+  push:
+    branches:
+      - "main"
+
+jobs:
+  push-base-docker-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: ./Dockerfiles/base-Dockerfile
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/offat-base:dev
+          platforms: linux/amd64,linux/arm64
+    
+    
+  push-cli-docker-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: ./Dockerfiles/cli-Dockerfile
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/offat:dev
+          platforms: linux/amd64,linux/arm64

--- a/.github/workflows/dev-push.yml
+++ b/.github/workflows/dev-push.yml
@@ -1,9 +1,9 @@
-name: "Build and Push Docker Image to DockerHub"
+name: "Dev Release: Build and Push Docker Image to DockerHub"
 
 on:
   push:
     branches:
-      - "main"
+      - "dev"
 
 jobs:
   push-base-docker-image:
@@ -26,8 +26,7 @@ jobs:
           push: true
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/offat-base:dev
           platforms: linux/amd64,linux/arm64
-    
-    
+
   push-cli-docker-image:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release-push.yml
+++ b/.github/workflows/release-push.yml
@@ -21,10 +21,11 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v3
         with:
-          platforms: linux/amd64,linux/arm64
-          push: true
+          context: .
           file: ./Dockerfiles/base-Dockerfile
+          push: true
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/offat-base:latest
+          platforms: linux/amd64,linux/arm64
     
     
   push-cli-docker-image:
@@ -42,7 +43,8 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v3
         with:
-          platforms: linux/amd64,linux/arm64
-          push: true
+          context: .
           file: ./Dockerfiles/cli-Dockerfile
+          push: true
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/offat:latest
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
* Release `latest` tag docker images on new releases
* Release `dev` tag docker images on new pushes on dev branch